### PR TITLE
Stop ignoring tests in root of src/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-and-run-tests:
 	src/snapshot-tests.bin
 
 tests:
-	g++ ${FLAGS} src/**/*.test.cpp ${CPP_SOURCE_FILES} -o bin/unit-tests
+	g++ ${FLAGS} src/**/*.test.cpp src/*.test.cpp ${CPP_SOURCE_FILES} -o bin/unit-tests
 
 test: tests
 	bin/unit-tests


### PR DESCRIPTION
Moved catch DEFINE statement and stop ignoring tests in the root of the `src/` directory
