### PR TITLE
4 use libsndfile or ni media for dealing with wav files 1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "dependencies/portaudio"]
 	path = dependencies/portaudio
 	url = https://github.com/PortAudio/portaudio.git
+[submodule "dependencies/libsndfile"]
+	path = dependencies/libsndfile
+	url = https://github.com/libsndfile/libsndfile.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,3 +134,7 @@ TARGET_LINK_LIBRARIES( test_naive LINK_PUBLIC ${LIBSNDFILE_LIBRARIES} )
 add_subdirectory(./dependencies/portaudio)
 target_link_libraries( naive PRIVATE PortAudio)
 target_link_libraries( test_naive PRIVATE PortAudio)
+
+add_subdirectory(./dependencies/libsndfile)
+target_link_libraries( naive PRIVATE SndFile::sndfile)
+target_link_libraries(naive PRIVATE SndFile::sndfile)

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1195 +1,337 @@
 [
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/main.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/main.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/main.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/main.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/file-io/record.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/file-io/record.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/file-io/record.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/file-io/record.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/core/Signal.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/core/Signal.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/core/Signal.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/core/Signal.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/playback/BufferedPlayback.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/playback/BufferedPlayback.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/Parse.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/Parse.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/LazyRegex.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/LazyRegex.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/NumberPatterns.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/NumberPatterns.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/Units.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/Units.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/NumberWithUnit.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/NumberWithUnit.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/Add.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/Add.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/Multiply.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/Multiply.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/BreakpointEnvelope.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/BreakpointEnvelope.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/ControlString.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/ControlString.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/file-io/piping.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/file-io/piping.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/parsing/RegularExpressionSources.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/parsing/RegularExpressionSources.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/Rhythm.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/Rhythm.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/cli/SignalString.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/cli/SignalString.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-I/Users/joelle/code/naive-instruments/dependencies",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/naive.dir/src/instruments/Osc.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/naive.dir/src/instruments/Osc.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/catch-config.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/catch-config.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/catch-config.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/catch-config.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/file-io/record.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/file-io/record.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/file-io/record.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/file-io/record.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/core/Signal.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/core/Signal.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/core/Signal.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/core/Signal.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/playback/BufferedPlayback.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/playback/BufferedPlayback.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/Parse.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/Parse.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/LazyRegex.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/LazyRegex.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/Units.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/Units.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/Add.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/Add.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/Multiply.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/Multiply.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/ControlString.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/ControlString.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/file-io/piping.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/file-io/piping.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/Rhythm.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/Rhythm.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/cli/SignalString.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/cli/SignalString.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/Osc.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/Osc.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/generative/Random.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/generative/Random.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/generative/Random.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/generative/Random.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/instruments/ControlString.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/instruments/ControlString.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/instruments/ControlString.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/LazyRegex.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/LazyRegex.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/core/Signal.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/core/Signal.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/core/Signal.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/core/Signal.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/core/Sample.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/core/Sample.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/core/Sample.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/core/Sample.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/parse.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/parse.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/parse.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/parse.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.test.cpp.o"
-  },
-  {
-    "arguments": [
-      "/usr/bin/clang++",
-      "-DBOOST_PROGRAM_OPTIONS_DYN_LINK",
-      "-DBOOST_PROGRAM_OPTIONS_NO_LIB",
-      "-I/opt/homebrew/Cellar/portaudio/19.7.0/include",
-      "-isystem",
-      "/opt/homebrew/include",
-      "-std=c++20",
-      "-stdlib=libc++",
-      "-arch",
-      "arm64",
-      "-isysroot",
-      "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk",
-      "-fPIE",
-      "-std=gnu++20",
-      "-c",
-      "-o",
-      "CMakeFiles/test_naive.dir/src/parsing/Units.test.cpp.o",
-      "/Users/joelle/code/naive-instruments/src/parsing/Units.test.cpp"
-    ],
-    "directory": "/Users/joelle/code/naive-instruments/build",
-    "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.test.cpp",
-    "output": "/Users/joelle/code/naive-instruments/build/CMakeFiles/test_naive.dir/src/parsing/Units.test.cpp.o"
-  }
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/main.cpp.o -c /Users/joelle/code/naive-instruments/src/main.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/main.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/file-io/record.cpp.o -c /Users/joelle/code/naive-instruments/src/file-io/record.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/file-io/record.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/core/Signal.cpp.o -c /Users/joelle/code/naive-instruments/src/core/Signal.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/core/Signal.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/playback/BufferedPlayback.cpp.o -c /Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/Parse.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/Parse.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/LazyRegex.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/NumberPatterns.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/Units.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/Units.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/NumberWithUnit.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/Add.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Add.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/Multiply.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/BreakpointEnvelope.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/ControlString.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/file-io/piping.cpp.o -c /Users/joelle/code/naive-instruments/src/file-io/piping.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/parsing/RegularExpressionSources.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/Rhythm.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/cli/SignalString.cpp.o -c /Users/joelle/code/naive-instruments/src/cli/SignalString.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/naive.dir/src/instruments/Osc.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Osc.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/catch-config.test.cpp.o -c /Users/joelle/code/naive-instruments/src/catch-config.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/catch-config.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/file-io/record.cpp.o -c /Users/joelle/code/naive-instruments/src/file-io/record.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/file-io/record.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/core/Signal.cpp.o -c /Users/joelle/code/naive-instruments/src/core/Signal.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/core/Signal.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/playback/BufferedPlayback.cpp.o -c /Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/playback/BufferedPlayback.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/Parse.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/Parse.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/Parse.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/LazyRegex.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/Units.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/Units.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/Add.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Add.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Add.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/Multiply.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Multiply.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/ControlString.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/file-io/piping.cpp.o -c /Users/joelle/code/naive-instruments/src/file-io/piping.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/file-io/piping.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/Rhythm.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Rhythm.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/cli/SignalString.cpp.o -c /Users/joelle/code/naive-instruments/src/cli/SignalString.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/cli/SignalString.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/Osc.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/Osc.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/Osc.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/signal/naming.test.cpp.o -c /Users/joelle/code/naive-instruments/src/signal/naming.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/signal/naming.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/signal/Signal.test.cpp.o -c /Users/joelle/code/naive-instruments/src/signal/Signal.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/signal/Signal.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/signal/signal-processes.test.cpp.o -c /Users/joelle/code/naive-instruments/src/signal/signal-processes.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/signal/signal-processes.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/signal/SignalShorthands.test.cpp.o -c /Users/joelle/code/naive-instruments/src/signal/SignalShorthands.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/signal/SignalShorthands.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/generative/Random.test.cpp.o -c /Users/joelle/code/naive-instruments/src/generative/Random.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/generative/Random.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/BreakpointEnvelope.test.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/BreakpointEnvelope.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/instruments/ControlString.test.cpp.o -c /Users/joelle/code/naive-instruments/src/instruments/ControlString.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/instruments/ControlString.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/LazyRegex.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/LazyRegex.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/LazyRegex.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/NumberPatterns.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberPatterns.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/NumberWithUnit.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/NumberWithUnit.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/core/Signal.test.cpp.o -c /Users/joelle/code/naive-instruments/src/core/Signal.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/core/Signal.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/core/Sample.test.cpp.o -c /Users/joelle/code/naive-instruments/src/core/Sample.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/core/Sample.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/parse.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/parse.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/parse.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/RegularExpressionSources.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/RegularExpressionSources.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build",
+  "command": "/usr/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DPA_USE_COREAUDIO=1 -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIE -std=gnu++20 -o CMakeFiles/test_naive.dir/src/parsing/Units.test.cpp.o -c /Users/joelle/code/naive-instruments/src/parsing/Units.test.cpp",
+  "file": "/Users/joelle/code/naive-instruments/src/parsing/Units.test.cpp"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_allocation.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_allocation.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_allocation.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_converters.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_converters.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_converters.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_cpuload.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_cpuload.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_cpuload.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_debugprint.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_debugprint.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_debugprint.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_dither.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_dither.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_dither.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_front.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_front.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_front.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_process.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_process.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_process.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_ringbuffer.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_ringbuffer.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_ringbuffer.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_stream.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_stream.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_stream.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/common/pa_trace.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_trace.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common/pa_trace.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/os/unix/pa_unix_hostapis.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix/pa_unix_hostapis.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix/pa_unix_hostapis.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/os/unix/pa_unix_util.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix/pa_unix_util.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix/pa_unix_util.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/hostapi/coreaudio/pa_mac_core.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/hostapi/coreaudio/pa_mac_core_blocking.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/portaudio",
+  "command": "/Library/Developer/CommandLineTools/usr/bin/cc -DPA_LITTLE_ENDIAN -DPA_USE_COREAUDIO=1 -DPortAudio_EXPORTS -I/opt/homebrew/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/include -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/common -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/os/unix -I/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -fPIC -std=gnu11 -o CMakeFiles/PortAudio.dir/src/hostapi/coreaudio/pa_mac_core_utilities.c.o -c /Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c",
+  "file": "/Users/joelle/code/naive-instruments/dependencies/portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c"
+},
+{
+  "directory": "/Users/joelle/code/naive-instruments/build/dependencies/ni-media/audiostream",
+  "command": "/usr/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DNIMEDIA_ENABLE_AIFF_DECODING=1 -DNIMEDIA_ENABLE_FLAC_DECODING=1 -DNIMEDIA_ENABLE_ITUNES_DECODING=0 -DNIMEDIA_ENABLE_MP3_DECODING=1 -DNIMEDIA_ENABLE_MP4_DECODING=1 -DNIMEDIA_ENABLE_OGG_DECODING=1 -DNIMEDIA_ENABLE_WAV_DECODING=1 -DNIMEDIA_ENABLE_WAV_ENCODING=1 -DNIMEDIA_ENABLE_WMA_DECODING=0 -Daudiostream_EXPORTS -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/inc -I/Users/joelle/code/naive-instruments/dependencies/ni-media/audiostream/src -I/Users/joelle/code/naive-instruments/dependencies/ni-media/pcm/inc -isystem /opt/homebrew/include  -std=c++20 -stdlib=libc++ -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -fPIC -std=gnu++14 -o CMakeFiles/audiostream.dir/Unity/unity_0_cxx.cxx.o -c /Users/joelle/code/naive-instruments/build/dependencies/ni-media/audiostream/CMakeFiles/audiostream.dir/Unity/unity_0_cxx.cxx",
+  "file": "/Users/joelle/code/naive-instruments/build/dependencies/ni-media/audiostream/CMakeFiles/audiostream.dir/Unity/unity_0_cxx.cxx"
+}
 ]

--- a/src/cli/AudioCommand.h
+++ b/src/cli/AudioCommand.h
@@ -131,7 +131,7 @@ protected:
         auto& path = outputFile();
         if ( stdoutIsAPipe() )
         {
-            record( std::cout, signal, outputDuration() );
+            recordToStdout( signal, outputDuration() );
         }
         else if ( interactiveModeEnabled() )
         {
@@ -151,7 +151,7 @@ protected:
         auto& path = outputFile();
         if ( stdoutIsAPipe() )
         {
-            record( std::cout, signal, outputDuration() );
+            recordToStdout( signal, outputDuration() );
         }
         else if ( interactiveModeEnabled() )
         {

--- a/src/cli/CommandLineApp.h
+++ b/src/cli/CommandLineApp.h
@@ -31,7 +31,7 @@ public:
 
         if ( stdoutIsAPipe() )
         {
-            WavWriter::write( std::cout, *buffer );
+            WavWriter::writeToStdout( *buffer );
         }
         else if ( outputPath().empty() )
         {
@@ -39,7 +39,7 @@ public:
         }
         else
         {
-            WavWriter::write( outputPath(), *buffer );
+            WavWriter::write( outputPath().c_str(), *buffer );
         }
     }
 
@@ -81,7 +81,7 @@ public:
         auto& path = outputPath();
         if ( stdoutIsAPipe() )
         {
-            record( std::cout, signal, duration() );
+            recordToStdout( signal, duration() );
         }
         else if ( path.empty() )
             BufferedPlayback::play( signal );

--- a/src/file-io/record.cpp
+++ b/src/file-io/record.cpp
@@ -3,38 +3,51 @@
 void record( const std::string& outputFile, std::shared_ptr<FrameStream<double>> signal, float duration )
 {
 
-    std::ofstream outputStream( outputFile, std::ios::binary );
-
-    record( outputStream, signal, duration );
+    double attenuation    = .5;
+    int    numberOfFrames = duration * sampleRate;
+    std::cerr << "Number of frames: " << numberOfFrames << "\n";
+    WavWriter recorder( outputFile.c_str(), numberOfFrames );
+    for ( int i = 0; i < numberOfFrames; ++i )
+        recorder << ( *signal )[i] * attenuation;
 }
 
 void record( const std::string& outputFile, NaiveInstruments::SignalShorthands::mono signal, float duration )
 {
 
-    std::ofstream outputStream( outputFile, std::ios::binary );
-    record( outputStream, signal, duration );
-}
-
-void record( std::ostream& outputFile, std::shared_ptr<FrameStream<double>> signal, float duration )
-{
-
     double attenuation = .5;
 
-    int       numberOfFrames = duration * sampleRate;
-    WavWriter recorder( outputFile, numberOfFrames );
+    int numberOfFrames = duration * sampleRate;
+    std::cerr << "Number of frames: " << numberOfFrames << "\n";
+    WavWriter recorder( outputFile.c_str(), numberOfFrames );
+
+    NaiveInstruments::SignalReader<double> reader;
+    reader = signal;
+
+    for ( int i = 0; i < numberOfFrames; ++i )
+        recorder << reader[i] * attenuation;
+}
+
+[[deprecated( "Writing wav files to pipes is a bad idea because the duration must be specified in the header" )]] void
+recordToStdout( std::shared_ptr<FrameStream<double>> signal, float duration )
+{
+    double attenuation    = .5;
+    int    numberOfFrames = duration * sampleRate;
+    std::cerr << "Number of frames: " << numberOfFrames << "\n";
+    WavWriter recorder( stdout, numberOfFrames );
     for ( int i = 0; i < numberOfFrames; ++i )
     {
         recorder << ( *signal )[i] * attenuation;
     }
 }
 
-void record( std::ostream& outputStream, NaiveInstruments::SignalShorthands::mono signal, float duration )
+void recordToStdout( NaiveInstruments::SignalShorthands::mono signal, float duration )
 {
-
     double attenuation = .5;
 
-    int       numberOfFrames = duration * sampleRate;
-    WavWriter recorder( outputStream, numberOfFrames );
+
+    int numberOfFrames = duration * sampleRate;
+    std::cerr << "Number of frames: " << numberOfFrames << "\n";
+    WavWriter recorder( stdout, numberOfFrames );
 
     NaiveInstruments::SignalReader<double> reader;
     reader = signal;

--- a/src/file-io/record.h
+++ b/src/file-io/record.h
@@ -10,5 +10,7 @@
  */
 void record( const std::string& outputFile, std::shared_ptr<FrameStream<double>> signal, float duration );
 void record( const std::string& outputFile, NaiveInstruments::SignalShorthands::mono signal, float duration );
-void record( std::ostream& outputStream, std::shared_ptr<FrameStream<double>> signal, float duration );
-void record( std::ostream& outputStream, NaiveInstruments::SignalShorthands::mono, float duration );
+[[deprecated( "Writing wav files to pipes is a bad idea because the duration must be specified in the header" )]] void
+recordToStdout( std::shared_ptr<FrameStream<double>> signal, float duration );
+[[deprecated( "Writing wav files to pipes is a bad idea because the duration must be specified in the header" )]] void
+recordToStdout( NaiveInstruments::SignalShorthands::mono, float duration );

--- a/src/test-framework/custom-assertions.h
+++ b/src/test-framework/custom-assertions.h
@@ -62,7 +62,7 @@ inline std::string record_and_checksum( const std::string                       
                                         std::shared_ptr<NaiveInstruments::Signal<double>> signal,
                                         int                                               durationInSamples )
 {
-    WavWriter                              writer( outputPath, durationInSamples );
+    WavWriter                              writer( outputPath.c_str(), durationInSamples );
     NaiveInstruments::SignalReader<double> reader;
     reader = signal;
 

--- a/tests/checkaudio.sh
+++ b/tests/checkaudio.sh
@@ -50,6 +50,7 @@ function checkaudio {
     done
   else
     if [ $stableChecksum != checksum ]; then
+      echo " ❌ Checksums for $sample did not match.\nExpected $stableChecksum, got $checksum"
       return 1;
     fi
   fi

--- a/tests/checksums.yaml
+++ b/tests/checksums.yaml
@@ -1,60 +1,30 @@
-Sine wave on middle C lasting one second.wav:
-  checksum: SHA256=5f7c7931c7195c0a8439b9dca624955df9de7c297c9cc78b5df510625fdcfeda
-Sawtooth wave on middle C lasting one second.wav:
-  checksum: SHA256=0c56b0fcaa93d4a3734ad9eebd7b332045e6af30e6904665b664c6c3bc3eb66e
-Square wave on middle C lasting one second.wav:
-  checksum: SHA256=1f0a59bee6cc97105f118033c963411367806c1b3abc08bd24620418b0600263
-Triangle wave on middle C lasting one second.wav:
-  checksum: SHA256=c54dc6ce7fd43bb75a28bbf3c4debce14a344f3aec47a6dfe2f2cbf2be1aca79
-Bass sawtooth wave.wav:
-  checksum: SHA256=47a3bf6e6aaf58f1472aac078358a8744ca024eacfa87949dd85236acaa44143
-Sine sweep accross entire grand piano range.wav:
-  checksum: SHA256=07117671d3adb2cd74ce1011f6da0b54a5fe94d3b51ad8e4cc538d800cdce3ea
-Upward sine sweep accross entire grand piano range.wav:
-  checksum: SHA256=671fd99b86e812a188ea31743ee676861600a0871fafd6d0db9f984bdcb5da60
-Middle C Sine wave with Vibrato.wav:
-  checksum: SHA256=5c6a68d9016a4cc763611e65ec329a14c44a3507d5b4aca21741d318caf2534c
-Simple boop.wav:
-  checksum: SHA256=bac2cd9da14bcbab03716a30c6d87c23f849e80625185315f9947426f1f0fbd5
-Slightly longer boop.wav:
-  checksum: SHA256=9b6b1b00365e01f214a73cd507805fe0d1d111818811f27810dfb2239d185ffb
-Trianglular boop.wav:
-  checksum: SHA256=5abc70cfbba3facd71eed72de0d1543d2074b8cd02cc4509cfb7aaa04bee9d96
-Sliding boop.wav:
-  checksum: SHA256=5487faf401a623cc484b1185c2ed66ba6ea478013366dd3d1936b84aa874db6f
-Simple FM tone.wav:
-  checksum: SHA256=efe375cb504c12b59ab92bcc16a3e15f6bab4d64fec445f4828e503f710f9e32
-FM Kick.wav:
-  checksum: SHA256=b6f12fbb87fac49e7ffd664bec5c82a0b7fedf6069c6c92947664e5a5e99b1b1
-120bpm metronome.wav:
-  checksum: SHA256=5bf073ce7ea82732d4fbe47acc336ae11359e5183a3a9253ce951dc30373e1c6
 results/120bpm metronome.wav:
-  checksum: SHA256=5bf073ce7ea82732d4fbe47acc336ae11359e5183a3a9253ce951dc30373e1c6
+  checksum: SHA256=e07a92e4b9786f7327cd30ec6529bfbe40270ea34bf60c57656af196cc414313
 results/Bass sawtooth wave.wav:
-  checksum: SHA256=47a3bf6e6aaf58f1472aac078358a8744ca024eacfa87949dd85236acaa44143
+  checksum: SHA256=1dac7d046affb82aee624327b0051a2764b33941ba7839bad386812da2049bf1
 results/FM Kick.wav:
-  checksum: SHA256=b6f12fbb87fac49e7ffd664bec5c82a0b7fedf6069c6c92947664e5a5e99b1b1
+  checksum: SHA256=6f9b79fc229a82c7af635ad8e2638ca70d6dbd2fe66fc455458a7d5f84ef8fbf
 results/Middle C Sine wave with Vibrato.wav:
-  checksum: SHA256=5c6a68d9016a4cc763611e65ec329a14c44a3507d5b4aca21741d318caf2534c
+  checksum: SHA256=08ad69dd4ce8accd9a757fe8bfd231f1a273d3919eb36fc35cfb23fdd24ab7eb
 results/Sawtooth wave on middle C lasting one second.wav:
-  checksum: SHA256=0c56b0fcaa93d4a3734ad9eebd7b332045e6af30e6904665b664c6c3bc3eb66e
+  checksum: SHA256=0067e56dab8a5518815bf704ecda4b1f1d1645baf52ad00601c99eca4317a851
 results/Simple FM tone.wav:
-  checksum: SHA256=efe375cb504c12b59ab92bcc16a3e15f6bab4d64fec445f4828e503f710f9e32
+  checksum: SHA256=a9059251100d9e14a2f24c4d5aacd58a0586685d8cc1f8dd4b1ef33e841f7288
 results/Simple boop.wav:
-  checksum: SHA256=bac2cd9da14bcbab03716a30c6d87c23f849e80625185315f9947426f1f0fbd5
+  checksum: SHA256=25e10bba5c7c00e956eb23896da638ccca980ee58e084417d074b32b713235c8
 results/Sine sweep accross entire grand piano range.wav:
-  checksum: SHA256=07117671d3adb2cd74ce1011f6da0b54a5fe94d3b51ad8e4cc538d800cdce3ea
+  checksum: SHA256=edb61ce88bcf4fda703b3c0c29b4d5ed7d1c388902b7014344320441813f0a9b
 results/Sine wave on middle C lasting one second.wav:
-  checksum: SHA256=5fd5f7c0c0a4b27c58fd239844dde39f670876dd0722157c4dbd62e713a93143
-results/Slightly longer boop.wav:
-  checksum: SHA256=9b6b1b00365e01f214a73cd507805fe0d1d111818811f27810dfb2239d185ffb
-results/Square wave on middle C lasting one second.wav:
-  checksum: SHA256=1f0a59bee6cc97105f118033c963411367806c1b3abc08bd24620418b0600263
-results/Triangle wave on middle C lasting one second.wav:
-  checksum: SHA256=c54dc6ce7fd43bb75a28bbf3c4debce14a344f3aec47a6dfe2f2cbf2be1aca79
-results/Trianglular boop.wav:
-  checksum: SHA256=5abc70cfbba3facd71eed72de0d1543d2074b8cd02cc4509cfb7aaa04bee9d96
-results/Upward sine sweep accross entire grand piano range.wav:
-  checksum: SHA256=671fd99b86e812a188ea31743ee676861600a0871fafd6d0db9f984bdcb5da60
+  checksum: SHA256=e84398525b4334dec4716c591c6924387077f4e570337e26f28fc40b98fd73d7
 results/Sliding boop.wav:
-  checksum: SHA256=5487faf401a623cc484b1185c2ed66ba6ea478013366dd3d1936b84aa874db6f
+  checksum: SHA256=53a4fbba206cfe395d94126a492e88d83d2b139a780cc85c4d271a97cb8733e4
+results/Slightly longer boop.wav:
+  checksum: SHA256=aba8533c7f674f2ef65eebdc643aa5e0d957e629253e135caa0cfce1984b3269
+results/Square wave on middle C lasting one second.wav:
+  checksum: SHA256=74b3f70ca580eec77e074788cc64e0c99a4fcc701a78cb109dbbe4814074b2b6
+results/Triangle wave on middle C lasting one second.wav:
+  checksum: SHA256=75a5212b3b14a54b6a8ec72905651ca78b5d2e33bc60ef9836b9c37f77ebe359
+results/Trianglular boop.wav:
+  checksum: SHA256=1aab36e0e67c4143628a11f6b622d9ba319a3be113c0acdbed9143dfb70cb4dd
+results/Upward sine sweep accross entire grand piano range.wav:
+  checksum: SHA256=d0e9aa32e88bb69e94cea2ddc40326bf2b13f9e16eb5a7127496ea5c0a220cbc


### PR DESCRIPTION
- Add libsndfile as submodule
- link libsndfile dependency with cmake
- WavWriter uses libsndfile (mono only)
- Update compile commands
- checkaudio: error message for bad checksum
- Update e2e checksums to match mono outputs
